### PR TITLE
Fixed invalid properties names

### DIFF
--- a/data/generate.ts
+++ b/data/generate.ts
@@ -99,13 +99,13 @@ const activity: TikTokActivityData = {
       "Web ID": faker.lorem.word(),
     })),
   },
-  "Video Browsing History": {
+  "Watch History": {
     VideoList: generateFavoriteElements(),
   },
 };
 
 const data: TikTokUserData = {
-  Activity: activity,
+  "Your Activity": activity,
   "App Settings": {
     Block: {
       BlockList: generateUserSchemaList(),
@@ -146,7 +146,7 @@ const data: TikTokUserData = {
   },
 
   Profile: {
-    "Profile Information": {
+    "Profile Info": {
       ProfileMap: {
         likesReceived: String(faker.number.int()),
         profilePhoto: faker.internet.url(),

--- a/data/generate.ts
+++ b/data/generate.ts
@@ -9,6 +9,17 @@ function generateFavoriteElements() {
   const elements = [];
   for (let i = 0; i < size; i++) {
     elements.push({
+      date: faker.date.past().toISOString(),
+      link: faker.internet.url(),
+    });
+  }
+  return elements;
+}
+
+function generateWatchHistoryElements() {
+  const elements = [];
+  for (let i = 0; i < size; i++) {
+    elements.push({
       Date: faker.date.past().toISOString(),
       Link: faker.internet.url(),
     });
@@ -100,7 +111,7 @@ const activity: TikTokActivityData = {
     })),
   },
   "Watch History": {
-    VideoList: generateFavoriteElements(),
+    VideoList: generateWatchHistoryElements(),
   },
 };
 
@@ -114,8 +125,8 @@ const data: TikTokUserData = {
   Comment: {
     Comments: {
       CommentsList: Array.from({ length: size }, () => ({
-        Date: faker.date.past().toISOString(),
-        Comment: faker.lorem.word(),
+        date: faker.date.past().toISOString(),
+        comment: faker.lorem.word(),
       })),
     },
   },

--- a/src/components/DataDonation/utils.ts
+++ b/src/components/DataDonation/utils.ts
@@ -5,7 +5,7 @@ function anonymizeUserData(userData: TikTokUserData) {
   return {
     ...userData,
     Activity: {
-      ...userData.Activity,
+      ...userData["Your Activity"],
       "Login History": null,
       "Most Recent Location Data": null,
       "Search History": null,
@@ -16,9 +16,9 @@ function anonymizeUserData(userData: TikTokUserData) {
     },
     "Direct Messages": null,
     Profile: {
-      "Profile Information": {
+      "Profile Info": {
         ProfileMap: {
-          ...userData.Profile["Profile Information"].ProfileMap,
+          ...userData.Profile["Profile Info"].ProfileMap,
           PlatformInfo: null,
           userName: "Anonymous",
           telephoneNumber: null,

--- a/src/components/Preparation/HowToGetFile.tsx
+++ b/src/components/Preparation/HowToGetFile.tsx
@@ -1,9 +1,8 @@
-import React from "react";
-import WrappedContainer from "../Wrapped/WrappedContainer";
+import { ChevronRight, ExternalLink } from "lucide-react";
 import Serif from "../Serif";
 import InfoText from "../Wrapped/InfoText";
+import WrappedContainer from "../Wrapped/WrappedContainer";
 import { Button } from "../ui/button";
-import { ChevronRight, ExternalLink } from "lucide-react";
 
 function HowToGetFile({ onContinue }: { onContinue: () => void }) {
   return (

--- a/src/components/Wrapped/Slides/WatchSessionLength.tsx
+++ b/src/components/Wrapped/Slides/WatchSessionLength.tsx
@@ -1,9 +1,8 @@
-import React from "react";
-import WrappedContainer, { WrappedSlideProps } from "../WrappedContainer";
+import formatTimeLength from "@/lib/utils/formatTimeLength";
+import CountUp from "react-countup";
 import FatHeading from "../FatHeading";
 import InfoText from "../InfoText";
-import CountUp from "react-countup";
-import formatTimeLength from "@/lib/utils/formatTimeLength";
+import WrappedContainer, { WrappedSlideProps } from "../WrappedContainer";
 
 function WatchSessionLength({ statistics }: WrappedSlideProps) {
   const { amount, unit } = formatTimeLength(

--- a/src/lib/Statistics/CommentsStatistic.ts
+++ b/src/lib/Statistics/CommentsStatistic.ts
@@ -33,9 +33,9 @@ export default class CommentsStatistic extends Statistic<CommentsStatisticResult
       const comment = commentList[i];
 
       totalComments++;
-      totalCommentLength += comment.Comment.length;
+      totalCommentLength += comment.comment.length;
 
-      const emojis = this.extractEmojis(comment.Comment);
+      const emojis = this.extractEmojis(comment.comment);
       emojis.forEach((emoji) => {
         if (emojiMap.has(emoji)) {
           emojiMap.set(emoji, emojiMap.get(emoji)! + 1);

--- a/src/lib/Statistics/LikesStatistic.ts
+++ b/src/lib/Statistics/LikesStatistic.ts
@@ -17,7 +17,9 @@ export default class LikesStatistic extends Statistic<LikesStatisticResult> {
 
   calculateResult(): LikesStatisticResult {
     const likedPosts =
-      this.wrapped.userData.Activity["Like List"].ItemFavoriteList?.reverse();
+      this.wrapped.userData["Your Activity"][
+        "Like List"
+      ].ItemFavoriteList?.reverse();
     const totalLikes = likedPosts?.length ?? 0;
     if (!likedPosts) {
       return {

--- a/src/lib/Statistics/LikesStatistic.ts
+++ b/src/lib/Statistics/LikesStatistic.ts
@@ -39,7 +39,7 @@ export default class LikesStatistic extends Statistic<LikesStatisticResult> {
     for (let i = 0; i < likedPosts.length; i++) {
       const post = likedPosts[i];
 
-      const date = new Date(post.Date);
+      const date = new Date(post.date);
       const day = date.toDateString();
       if (likedPerDay.has(day)) {
         likedPerDay.set(day, likedPerDay.get(day)! + 1);
@@ -54,8 +54,8 @@ export default class LikesStatistic extends Statistic<LikesStatisticResult> {
       totalLikes: totalLikes,
       dayWithMostLikedPosts: mostLikedDay,
       firstLikedVideo: {
-        date: likedPosts[0].Date,
-        link: likedPosts[0].Link ?? "",
+        date: likedPosts[0].date,
+        link: likedPosts[0].link ?? "",
       },
     };
   }

--- a/src/lib/Statistics/SharesStatistic.ts
+++ b/src/lib/Statistics/SharesStatistic.ts
@@ -22,7 +22,7 @@ export default class SharesStatistic extends Statistic<SharesStatisticResult> {
     };
 
     const sharedPosts =
-      this.wrapped.userData.Activity[
+      this.wrapped.userData["Your Activity"][
         "Share History"
       ].ShareHistoryList?.reverse();
     const totalShares = sharedPosts?.length ?? 0;

--- a/src/lib/Statistics/SharesStatistic.ts
+++ b/src/lib/Statistics/SharesStatistic.ts
@@ -22,9 +22,7 @@ export default class SharesStatistic extends Statistic<SharesStatisticResult> {
     };
 
     const sharedPosts =
-      this.wrapped.userData["Your Activity"][
-        "Share History"
-      ].ShareHistoryList?.reverse();
+      this.wrapped.userData["Your Activity"]["Share History"].ShareHistoryList;
     const totalShares = sharedPosts?.length ?? 0;
     if (!sharedPosts) {
       return {

--- a/src/lib/Statistics/VideoAmountWatchedStatistic.ts
+++ b/src/lib/Statistics/VideoAmountWatchedStatistic.ts
@@ -5,7 +5,7 @@ export default class VideoAmountWatchedStatistic extends Statistic<number> {
 
   calculateResult(): number {
     return (
-      this.wrapped.userData.Activity["Video Browsing History"].VideoList
+      this.wrapped.userData["Your Activity"]["Watch History"].VideoList
         ?.length ?? 0
     );
   }

--- a/src/lib/Statistics/WatchSessionsStatistic.ts
+++ b/src/lib/Statistics/WatchSessionsStatistic.ts
@@ -1,5 +1,5 @@
-import Statistic from "./Statistic";
 import * as Sentry from "@sentry/nextjs";
+import Statistic from "./Statistic";
 
 export type WatchSessionsStatisticResult = {
   totalWatchTimeSec: number;
@@ -39,8 +39,8 @@ export default class WatchSessionsStatistic extends Statistic<WatchSessionsStati
     let currentSessionStartTime = null;
     let sessionLengths = [];
 
-    const videoList = this.wrapped.userData.Activity[
-      "Video Browsing History"
+    const videoList = this.wrapped.userData["Your Activity"][
+      "Watch History"
     ].VideoList?.sort((a, b) => {
       return new Date(a.Date).getTime() - new Date(b.Date).getTime();
     });

--- a/src/lib/Wrapped.ts
+++ b/src/lib/Wrapped.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+import seedrandom from "seedrandom";
 import SpotifyFramePlayer from "./Spotify/FramePlayer";
 import CommentsStatistic, {
   CommentsStatisticResult,
@@ -6,6 +8,9 @@ import LikesStatistic, {
   LikesStatisticResult,
 } from "./Statistics/LikesStatistic";
 import LiveStatistic, { LiveStatisticResult } from "./Statistics/LiveStatistic";
+import defaultPersonas, {
+  TikTokEnjoyer,
+} from "./Statistics/Personas/defaultPersonas";
 import Persona from "./Statistics/Personas/Persona";
 import SharesStatistic, {
   SharesStatisticResult,
@@ -16,11 +21,6 @@ import WatchSessionsStatistic, {
   WatchSessionsStatisticResult,
 } from "./Statistics/WatchSessionsStatistic";
 import { TikTokUserData } from "./types";
-import defaultPersonas, {
-  TikTokEnjoyer,
-} from "./Statistics/Personas/defaultPersonas";
-import seedrandom from "seedrandom";
-import * as Sentry from "@sentry/nextjs";
 
 export type Statistics = {
   name: string;
@@ -94,9 +94,9 @@ export default class Wrapped {
 
   constructor(public userData: TikTokUserData) {
     if (
-      userData.Activity &&
-      (!userData.Activity["Video Browsing History"].VideoList ||
-        userData.Activity["Video Browsing History"].VideoList?.length === 0)
+      userData["Your Activity"] &&
+      (!userData["Your Activity"]["Watch History"].VideoList ||
+        userData["Your Activity"]["Watch History"].VideoList?.length === 0)
     ) {
       this.possiblyEmptyExport = true;
     }
@@ -110,7 +110,7 @@ export default class Wrapped {
     }
 
     return {
-      name: this.userData.Profile["Profile Information"].ProfileMap.userName,
+      name: this.userData.Profile["Profile Info"].ProfileMap.userName,
       videoAmountWatched: this.calculateStatistic(VideoAmountWatchedStatistic),
       watchSessions: this.calculateStatistic(WatchSessionsStatistic),
       comments: this.calculateStatistic(CommentsStatistic),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
 export const TikTokFavouriteElementSchema = z.object({
+  date: z.string(),
+  link: z.string().optional().nullable(),
+});
+
+export const TikTokWatchHistoryElementSchema = z.object({
   Date: z.string(),
   Link: z.string().optional().nullable(),
 });
@@ -47,8 +52,8 @@ export const TikTokStatusElementSchema = z.object({
 });
 
 export const TikTokCommentElementSchema = z.object({
-  Date: z.string(),
-  Comment: z.string(),
+  date: z.string(),
+  comment: z.string(),
 });
 
 export const TikTokLiveCommentElementSchema = z.object({
@@ -138,7 +143,7 @@ export const TikTokActivityDataSchema = z.object({
     "Status List": z.array(TikTokStatusElementSchema).nullable().optional(),
   }),
   "Watch History": z.object({
-    VideoList: z.array(TikTokFavouriteElementSchema).nullable().optional(),
+    VideoList: z.array(TikTokWatchHistoryElementSchema).nullable().optional(),
   }),
 });
 
@@ -191,6 +196,9 @@ export type TikTokUserData = z.infer<typeof TikTokUserDataSchema>;
 export type TikTokActivityData = z.infer<typeof TikTokActivityDataSchema>;
 export type TikTokFavouritesList = z.infer<
   typeof TikTokFavouriteElementSchema
+>[];
+export type TikTokWatchHistoryList = z.infer<
+  typeof TikTokWatchHistoryElementSchema
 >[];
 export type TikTokFavouriteElement = z.infer<
   typeof TikTokFavouriteElementSchema

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -137,13 +137,13 @@ export const TikTokActivityDataSchema = z.object({
   Status: z.object({
     "Status List": z.array(TikTokStatusElementSchema).nullable().optional(),
   }),
-  "Video Browsing History": z.object({
+  "Watch History": z.object({
     VideoList: z.array(TikTokFavouriteElementSchema).nullable().optional(),
   }),
 });
 
 export const TikTokUserDataSchema = z.object({
-  Activity: TikTokActivityDataSchema,
+  "Your Activity": TikTokActivityDataSchema,
   "App Settings": z.object({
     Block: z.object({
       BlockList: z.array(TikTokUserSchema).nullable().optional(),
@@ -165,7 +165,7 @@ export const TikTokUserDataSchema = z.object({
     }),
   }),
   Profile: z.object({
-    "Profile Information": z.object({
+    "Profile Info": z.object({
       ProfileMap: z.object({
         likesReceived: z.string(),
         profilePhoto: z.string(),


### PR DESCRIPTION
Since TikTok changed schema of exported json file, some properties was invalid.
Changed:
- "Profile Information" -> "Profile Info"
- "Activity" -> "Your Activity"
- "Video Browsing History" -> "Watch History"
- Added type for "Wwach History"
- Changed some "Date" -> "date", "Link" -> "link" in some types
- Fixed "Shares" statistic unnecessary `reverse()`